### PR TITLE
feat(app): detect repo code changes and prompt/auto-relaunch

### DIFF
--- a/src/cdash/app.tcss
+++ b/src/cdash/app.tcss
@@ -40,6 +40,12 @@ StatusBar #today-stats {
     color: $text-muted;
 }
 
+StatusBar #code-changed {
+    width: auto;
+    margin-left: 1;
+    color: $warning;
+}
+
 /* ============================================
    TODAY HEADER (Hero Component)
    ============================================ */

--- a/src/cdash/data/code_watcher.py
+++ b/src/cdash/data/code_watcher.py
@@ -1,0 +1,99 @@
+"""Code change detection for auto-reload functionality."""
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CodeChangeStatus:
+    """Status of code changes since app start."""
+
+    has_changes: bool
+    changed_files: list[str]
+
+
+def get_repo_root() -> Path | None:
+    """Get the root of the git repository.
+
+    Returns:
+        Path to repo root, or None if not in a git repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def get_tracked_python_files(repo_root: Path) -> list[Path]:
+    """Get all tracked Python files in src/.
+
+    Args:
+        repo_root: Root of the git repository.
+
+    Returns:
+        List of tracked .py file paths.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "src/**/*.py"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            files = [repo_root / f for f in result.stdout.strip().split("\n") if f]
+            return files
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return []
+
+
+def check_code_changes(start_time: float, repo_root: Path | None = None) -> CodeChangeStatus:
+    """Check if any tracked Python files changed since start_time.
+
+    Args:
+        start_time: Unix timestamp when the app started.
+        repo_root: Optional repo root path. Auto-detected if not provided.
+
+    Returns:
+        CodeChangeStatus with change info.
+    """
+    if repo_root is None:
+        repo_root = get_repo_root()
+
+    if repo_root is None:
+        return CodeChangeStatus(has_changes=False, changed_files=[])
+
+    tracked_files = get_tracked_python_files(repo_root)
+    changed = []
+
+    for filepath in tracked_files:
+        try:
+            if filepath.exists():
+                mtime = filepath.stat().st_mtime
+                if mtime > start_time:
+                    changed.append(filepath.name)
+        except OSError:
+            pass
+
+    return CodeChangeStatus(has_changes=len(changed) > 0, changed_files=changed)
+
+
+def relaunch_app() -> None:
+    """Relaunch the current application.
+
+    Replaces the current process with a new instance.
+    """
+    os.execv(sys.executable, [sys.executable] + sys.argv)

--- a/tests/test_code_watcher.py
+++ b/tests/test_code_watcher.py
@@ -1,0 +1,213 @@
+"""Tests for code change detection."""
+
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cdash.data.code_watcher import (
+    CodeChangeStatus,
+    check_code_changes,
+    get_repo_root,
+    get_tracked_python_files,
+)
+
+
+class TestCodeChangeStatus:
+    """Tests for CodeChangeStatus dataclass."""
+
+    def test_creates_status(self):
+        """Test creating a status object."""
+        status = CodeChangeStatus(has_changes=True, changed_files=["foo.py", "bar.py"])
+        assert status.has_changes is True
+        assert status.changed_files == ["foo.py", "bar.py"]
+
+    def test_no_changes(self):
+        """Test status with no changes."""
+        status = CodeChangeStatus(has_changes=False, changed_files=[])
+        assert status.has_changes is False
+        assert status.changed_files == []
+
+
+class TestGetRepoRoot:
+    """Tests for get_repo_root function."""
+
+    def test_returns_path_in_git_repo(self):
+        """Test returns a path when in a git repo."""
+        # The test itself runs in a git repo
+        root = get_repo_root()
+        # Should return something (we're in a git repo)
+        assert root is not None
+        assert root.exists()
+
+    @patch("subprocess.run")
+    def test_returns_none_on_error(self, mock_run):
+        """Test returns None when git command fails."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        root = get_repo_root()
+        assert root is None
+
+    @patch("subprocess.run")
+    def test_returns_none_on_timeout(self, mock_run):
+        """Test returns None on timeout."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=5)
+        root = get_repo_root()
+        assert root is None
+
+
+class TestGetTrackedPythonFiles:
+    """Tests for get_tracked_python_files function."""
+
+    def test_returns_list(self):
+        """Test returns a list of paths."""
+        root = get_repo_root()
+        if root:
+            files = get_tracked_python_files(root)
+            assert isinstance(files, list)
+            # Should find some Python files
+            assert len(files) > 0
+            # All should be .py files
+            for f in files:
+                assert f.suffix == ".py"
+
+    @patch("subprocess.run")
+    def test_returns_empty_on_error(self, mock_run):
+        """Test returns empty list when git command fails."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        files = get_tracked_python_files(Path("/tmp"))
+        assert files == []
+
+
+class TestCheckCodeChanges:
+    """Tests for check_code_changes function."""
+
+    def test_no_changes_when_recent_start(self):
+        """Test no changes detected when app just started."""
+        start_time = time.time()
+        status = check_code_changes(start_time)
+        # Files shouldn't have been modified after we started
+        assert status.has_changes is False
+        assert status.changed_files == []
+
+    def test_detects_changes_with_old_start_time(self):
+        """Test detects changes when start time is old."""
+        # Use a very old start time
+        start_time = 0.0
+        status = check_code_changes(start_time)
+        # All files will appear changed since they were modified after epoch
+        assert status.has_changes is True
+        assert len(status.changed_files) > 0
+
+    def test_returns_no_changes_when_not_in_repo(self):
+        """Test returns no changes when not in a git repo."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Pass a non-repo directory
+            status = check_code_changes(time.time(), Path(tmpdir))
+            assert status.has_changes is False
+            assert status.changed_files == []
+
+    def test_returns_no_changes_when_repo_root_is_none(self):
+        """Test returns no changes when repo root is None."""
+        with patch("cdash.data.code_watcher.get_repo_root", return_value=None):
+            status = check_code_changes(time.time(), None)
+            assert status.has_changes is False
+
+
+class TestStatusBarCodeChanged:
+    """Tests for StatusBar code changed indicator."""
+
+    @pytest.mark.asyncio
+    async def test_status_bar_has_code_changed_widget(self):
+        """Test status bar contains code-changed widget."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import Static
+
+            from cdash.app import StatusBar
+
+            status_bar = app.query_one(StatusBar)
+            code_changed = status_bar.query_one("#code-changed", Static)
+            assert code_changed is not None
+
+    @pytest.mark.asyncio
+    async def test_code_changed_indicator_shows(self):
+        """Test code changed indicator updates."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import Static
+
+            from cdash.app import StatusBar
+
+            status_bar = app.query_one(StatusBar)
+            status_bar.show_code_changed(True, 3)
+            code_changed = status_bar.query_one("#code-changed", Static)
+            # Use render() method for Textual Static widgets
+            console = code_changed.app.console
+            with console.capture() as capture:
+                console.print(code_changed.render())
+            rendered = capture.get()
+            assert "3 files changed" in rendered or "3 file" in rendered
+
+    @pytest.mark.asyncio
+    async def test_code_changed_indicator_singular(self):
+        """Test code changed indicator uses singular form."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import Static
+
+            from cdash.app import StatusBar
+
+            status_bar = app.query_one(StatusBar)
+            status_bar.show_code_changed(True, 1)
+            code_changed = status_bar.query_one("#code-changed", Static)
+            console = code_changed.app.console
+            with console.capture() as capture:
+                console.print(code_changed.render())
+            rendered = capture.get()
+            assert "1 file changed" in rendered or "1 file" in rendered
+
+    @pytest.mark.asyncio
+    async def test_code_changed_indicator_hides(self):
+        """Test code changed indicator hides when no changes."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import Static
+
+            from cdash.app import StatusBar
+
+            status_bar = app.query_one(StatusBar)
+            status_bar.show_code_changed(False, 0)
+            code_changed = status_bar.query_one("#code-changed", Static)
+            console = code_changed.app.console
+            with console.capture() as capture:
+                console.print(code_changed.render())
+            rendered = capture.get().strip()
+            assert rendered == ""
+
+
+class TestRelaunchBinding:
+    """Tests for relaunch key binding."""
+
+    @pytest.mark.asyncio
+    async def test_r_binding_exists(self):
+        """Test r key binding is registered."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        # BINDINGS are tuples: (key, action, description)
+        bindings = {b[0]: b[1] for b in app.BINDINGS}
+        assert "r" in bindings
+        assert "relaunch" in bindings["r"]


### PR DESCRIPTION
## Summary
- Add code_watcher module to detect file changes since app start using git ls-files
- Show amber indicator in status bar with file count when code changes detected
- Add `r` keybinding to relaunch app and pick up code changes
- 16 new tests covering the code watcher functionality

Fixes #8

## Test plan
- [x] Run `pytest tests/ -v` - all 176 tests pass
- [x] Verify status bar shows change indicator when editing .py files
- [x] Verify `r` key relaunches the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)