### PR TITLE
feat(ui): accurate refresh timestamps per panel

### DIFF
--- a/src/cdash/app.tcss
+++ b/src/cdash/app.tcss
@@ -75,10 +75,41 @@ TodayHeader > .spacer {
     width: 1fr;
 }
 
-TodayHeader > .refresh-info {
+TodayHeader > .refresh-info,
+TodayHeader > RefreshIndicator {
     color: $text-muted;
     width: auto;
     text-align: right;
+}
+
+/* ============================================
+   REFRESH INDICATORS
+   ============================================ */
+
+RefreshIndicator {
+    color: $text-muted;
+    width: auto;
+    text-align: right;
+}
+
+.header-spacer {
+    width: 1fr;
+}
+
+/* Panel header layouts */
+SessionsHeader,
+ToolsHeader,
+CIHeader {
+    height: 1;
+    width: 100%;
+}
+
+SessionsHeader > .section-title,
+ToolsHeader > .section-title,
+CIHeader > .ci-header {
+    text-style: bold;
+    color: $secondary;
+    width: auto;
 }
 
 /* ============================================

--- a/src/cdash/components/ci.py
+++ b/src/cdash/components/ci.py
@@ -4,10 +4,11 @@ from datetime import datetime, timezone
 
 from textual import work
 from textual.app import ComposeResult
-from textual.containers import Center, Vertical
+from textual.containers import Center, Horizontal, Vertical
 from textual.widgets import LoadingIndicator, Static
 from textual.worker import Worker
 
+from cdash.components.indicators import RefreshIndicator
 from cdash.data.github import (
     RepoStats,
     WorkflowRun,
@@ -34,6 +35,15 @@ def format_relative_time(dt: datetime) -> str:
     return f"{days}d ago"
 
 
+class CIHeader(Horizontal):
+    """Header with title and refresh indicator."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("CI ACTIVITY (today)", classes="ci-header")
+        yield Static("", classes="header-spacer")
+        yield RefreshIndicator(id="ci-refresh")
+
+
 class CIActivityPanel(Vertical):
     """Compact CI activity panel for Overview tab."""
 
@@ -45,7 +55,7 @@ class CIActivityPanel(Vertical):
         self._top_repos: list[RepoStats] = []
 
     def compose(self) -> ComposeResult:
-        yield Static("CI ACTIVITY (today)", classes="ci-header")
+        yield CIHeader()
         yield Static("", classes="ci-stats")
         yield Static("", classes="ci-repos")
         yield Static("[6: CI tab]", classes="ci-hint")
@@ -56,6 +66,12 @@ class CIActivityPanel(Vertical):
         self._passed = passed
         self._failed = failed
         self._refresh_display()
+        # Mark refresh indicator
+        try:
+            indicator = self.query_one("#ci-refresh", RefreshIndicator)
+            indicator.mark_refreshed()
+        except Exception:
+            pass
 
     def update_repos(self, stats: list[RepoStats]) -> None:
         """Update top repos list."""

--- a/src/cdash/components/header.py
+++ b/src/cdash/components/header.py
@@ -6,6 +6,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Static
 
+from cdash.components.indicators import RefreshIndicator
 from cdash.theme import CORAL
 
 
@@ -25,7 +26,7 @@ class TodayHeader(Horizontal):
         yield Static("", id="tools-stat", classes="stat-block")
         yield Static("", id="active-stat", classes="stat-block")
         yield Static("", classes="spacer")
-        yield Static("", id="refresh-info", classes="refresh-info")
+        yield RefreshIndicator(id="refresh-info")
 
     def update_stats(self, msgs: int = 0, tools: int = 0, active: int = 0) -> None:
         """Update the displayed stats.
@@ -43,7 +44,11 @@ class TodayHeader(Horizontal):
     def mark_refreshed(self) -> None:
         """Mark data as just refreshed."""
         self._last_refresh = time.time()
-        self._update_display()
+        try:
+            indicator = self.query_one("#refresh-info", RefreshIndicator)
+            indicator.mark_refreshed()
+        except Exception:
+            pass
 
     def _update_display(self) -> None:
         """Update all display widgets."""
@@ -51,12 +56,10 @@ class TodayHeader(Horizontal):
             msgs_widget = self.query_one("#msgs-stat", Static)
             tools_widget = self.query_one("#tools-stat", Static)
             active_widget = self.query_one("#active-stat", Static)
-            refresh_widget = self.query_one("#refresh-info", Static)
 
             msgs_widget.update(f"[{CORAL} bold]{self._msgs}[/] messages")
             tools_widget.update(f"[{CORAL} bold]{self._tools}[/] tools")
             active_widget.update(f"[{CORAL} bold]{self._active}[/] active")
-            refresh_widget.update(f"↻ {self._format_refresh_ago()}")
         except Exception:
             # Widget may not be mounted yet
             pass

--- a/src/cdash/components/indicators.py
+++ b/src/cdash/components/indicators.py
@@ -1,0 +1,55 @@
+"""Refresh indicator widgets for auto-updating panels."""
+
+import time
+
+from textual.widgets import Static
+
+
+class RefreshIndicator(Static):
+    """Auto-updating timestamp indicator.
+
+    Shows "↻ Xs ago" and updates every second via CSS animation trick.
+    Parent widget should call mark_refreshed() when data is fetched.
+    """
+
+    def __init__(self, id: str | None = None) -> None:
+        super().__init__("", id=id)
+        self._last_refresh: float = 0.0
+        self._update_timer = None
+
+    def on_mount(self) -> None:
+        """Start the update timer when mounted."""
+        # Update every second to keep the time display fresh
+        self._update_timer = self.set_interval(1.0, self._tick)
+
+    def mark_refreshed(self) -> None:
+        """Mark data as just refreshed."""
+        self._last_refresh = time.time()
+        self._update_display()
+
+    def _tick(self) -> None:
+        """Called every second to update display."""
+        self._update_display()
+
+    def _update_display(self) -> None:
+        """Update the displayed time."""
+        self.update(f"↻ {self._format_refresh_ago()}")
+
+    def _format_refresh_ago(self) -> str:
+        """Format time since last refresh as human-readable."""
+        if self._last_refresh == 0:
+            return "..."
+
+        elapsed = int(time.time() - self._last_refresh)
+        if elapsed < 60:
+            return f"{elapsed}s"
+        mins = elapsed // 60
+        if mins < 60:
+            return f"{mins}m"
+        hours = mins // 60
+        return f"{hours}h"
+
+    @property
+    def last_refresh(self) -> float:
+        """Get the timestamp of last refresh."""
+        return self._last_refresh

--- a/src/cdash/components/sessions.py
+++ b/src/cdash/components/sessions.py
@@ -1,9 +1,10 @@
 """Active sessions widget for displaying Claude Code sessions."""
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Static
 
+from cdash.components.indicators import RefreshIndicator
 from cdash.data.sessions import Session, format_duration, load_all_sessions
 from cdash.theme import AMBER, GREEN
 
@@ -48,12 +49,21 @@ class SessionItem(Static):
         return f'{status} {project_display:<16} "{preview}" {tool} {duration}'
 
 
+class SessionsHeader(Horizontal):
+    """Header with title and refresh indicator."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("ACTIVE SESSIONS", classes="section-title")
+        yield Static("", classes="header-spacer")
+        yield RefreshIndicator(id="sessions-refresh")
+
+
 class ActiveSessionsPanel(Vertical):
     """Panel displaying active sessions."""
 
     def compose(self) -> ComposeResult:
         """Compose the panel."""
-        yield Static("ACTIVE SESSIONS", classes="section-title")
+        yield SessionsHeader()
         yield from self._build_session_items()
 
     def _build_session_items(self) -> list[Static]:
@@ -88,3 +98,10 @@ class ActiveSessionsPanel(Vertical):
         # Add new items
         for item in self._build_session_items():
             self.mount(item)
+
+        # Mark refresh indicator
+        try:
+            indicator = self.query_one("#sessions-refresh", RefreshIndicator)
+            indicator.mark_refreshed()
+        except Exception:
+            pass

--- a/src/cdash/components/tools.py
+++ b/src/cdash/components/tools.py
@@ -1,9 +1,10 @@
 """Tool breakdown widget for displaying tool usage statistics."""
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Static
 
+from cdash.components.indicators import RefreshIndicator
 from cdash.data.tools import get_tool_usage_for_date
 from cdash.theme import BLUE, CORAL, TEXT_MUTED
 
@@ -51,12 +52,21 @@ class ToolItem(Static):
         return f"{self.tool_name:<10} {bar} [{CORAL}]{self.count:>3}[/]"
 
 
+class ToolsHeader(Horizontal):
+    """Header with title and refresh indicator."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("TOOL BREAKDOWN (today)", classes="section-title")
+        yield Static("", classes="header-spacer")
+        yield RefreshIndicator(id="tools-refresh")
+
+
 class ToolBreakdownPanel(Vertical):
     """Panel displaying tool usage breakdown for today."""
 
     def compose(self) -> ComposeResult:
         """Compose the tool breakdown panel."""
-        yield Static("TOOL BREAKDOWN (today)", classes="section-title")
+        yield ToolsHeader()
         yield from self._build_tool_items()
 
     def _build_tool_items(self) -> list[Static]:
@@ -87,3 +97,10 @@ class ToolBreakdownPanel(Vertical):
         # Add new items
         for item in self._build_tool_items():
             self.mount(item)
+
+        # Mark refresh indicator
+        try:
+            indicator = self.query_one("#tools-refresh", RefreshIndicator)
+            indicator.mark_refreshed()
+        except Exception:
+            pass

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,116 @@
+"""Tests for RefreshIndicator widget."""
+
+import time
+
+import pytest
+
+from cdash.components.indicators import RefreshIndicator
+
+
+class TestRefreshIndicator:
+    """Tests for RefreshIndicator widget."""
+
+    @pytest.mark.asyncio
+    async def test_indicator_creates(self):
+        """RefreshIndicator can be created."""
+        indicator = RefreshIndicator()
+        assert indicator is not None
+
+    @pytest.mark.asyncio
+    async def test_indicator_default_timestamp(self):
+        """RefreshIndicator starts with zero timestamp."""
+        indicator = RefreshIndicator()
+        assert indicator.last_refresh == 0.0
+
+    @pytest.mark.asyncio
+    async def test_mark_refreshed_sets_timestamp(self):
+        """mark_refreshed() sets current timestamp."""
+        indicator = RefreshIndicator()
+        before = time.time()
+        indicator.mark_refreshed()
+        after = time.time()
+
+        assert indicator.last_refresh >= before
+        assert indicator.last_refresh <= after
+
+    @pytest.mark.asyncio
+    async def test_format_never_refreshed(self):
+        """Shows ... when never refreshed."""
+        indicator = RefreshIndicator()
+        assert indicator._format_refresh_ago() == "..."
+
+    @pytest.mark.asyncio
+    async def test_format_seconds_ago(self):
+        """Shows seconds for recent refresh."""
+        indicator = RefreshIndicator()
+        indicator._last_refresh = time.time() - 5
+        result = indicator._format_refresh_ago()
+        assert "s" in result
+        assert "5" in result
+
+    @pytest.mark.asyncio
+    async def test_format_minutes_ago(self):
+        """Shows minutes for older refresh."""
+        indicator = RefreshIndicator()
+        indicator._last_refresh = time.time() - 120  # 2 minutes
+        result = indicator._format_refresh_ago()
+        assert "2m" in result
+
+    @pytest.mark.asyncio
+    async def test_format_hours_ago(self):
+        """Shows hours for much older refresh."""
+        indicator = RefreshIndicator()
+        indicator._last_refresh = time.time() - 7200  # 2 hours
+        result = indicator._format_refresh_ago()
+        assert "2h" in result
+
+    @pytest.mark.asyncio
+    async def test_with_id(self):
+        """RefreshIndicator can be created with id."""
+        indicator = RefreshIndicator(id="my-indicator")
+        assert indicator.id == "my-indicator"
+
+
+class TestRefreshIndicatorIntegration:
+    """Integration tests for RefreshIndicator in panels."""
+
+    @pytest.mark.asyncio
+    async def test_sessions_panel_has_refresh_indicator(self):
+        """ActiveSessionsPanel contains refresh indicator."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            # Find the indicator
+            indicator = app.query_one("#sessions-refresh", RefreshIndicator)
+            assert indicator is not None
+
+    @pytest.mark.asyncio
+    async def test_tools_panel_has_refresh_indicator(self):
+        """ToolBreakdownPanel contains refresh indicator."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            indicator = app.query_one("#tools-refresh", RefreshIndicator)
+            assert indicator is not None
+
+    @pytest.mark.asyncio
+    async def test_ci_panel_has_refresh_indicator(self):
+        """CIActivityPanel contains refresh indicator."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            indicator = app.query_one("#ci-refresh", RefreshIndicator)
+            assert indicator is not None
+
+    @pytest.mark.asyncio
+    async def test_header_has_refresh_indicator(self):
+        """TodayHeader contains refresh indicator."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            indicator = app.query_one("#refresh-info", RefreshIndicator)
+            assert indicator is not None


### PR DESCRIPTION
## Summary

- Add `RefreshIndicator` widget that auto-updates every second to show accurate "Xs ago" timestamps
- Each auto-updating panel now shows when its data was last refreshed:
  - TodayHeader: `↻ 3s`
  - Active Sessions: `↻ 3s`
  - Tool Breakdown: `↻ 3s`
  - CI Activity: `↻ 60s` (API rate limited)

## Implementation

- New `RefreshIndicator(Static)` widget with `set_interval(1.0)` timer
- Each panel tracks its own `_last_refresh` timestamp
- Panels call `mark_refreshed()` when data fetches complete
- CSS layout uses flex spacer to push indicator to the right

## Test plan

- [x] 12 new tests for RefreshIndicator widget
- [x] Integration tests verify indicator presence in all panels
- [x] All 172 tests pass

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)