### PR TITLE
fix(sessions): show parent project name for worktree sessions

### DIFF
--- a/src/cdash/components/sessions.py
+++ b/src/cdash/components/sessions.py
@@ -9,6 +9,24 @@ from cdash.data.sessions import Session, format_duration, load_all_sessions
 from cdash.theme import AMBER, GREEN
 
 
+def format_project_display(project_name: str | None) -> str:
+    """Format project name for display, handling worktrees.
+
+    For worktrees like '/path/to/project/.worktrees/8', returns 'project#8'.
+    For regular paths like '/path/to/project', returns 'project'.
+    """
+    if not project_name:
+        return "unknown"
+
+    if "/.worktrees/" in project_name:
+        parts = project_name.split("/.worktrees/")
+        parent = parts[0].split("/")[-1]
+        worktree = parts[1].split("/")[0]
+        return f"{parent}#{worktree}"
+
+    return project_name.split("/")[-1]
+
+
 class SessionItem(Static):
     """A single session item in the list."""
 
@@ -28,8 +46,8 @@ class SessionItem(Static):
         else:
             status = "[dim]○[/]"
 
-        # Project name (last component of path)
-        project_display = s.project_name.split("/")[-1] if s.project_name else "unknown"
+        # Project name (handles worktrees)
+        project_display = format_project_display(s.project_name)
 
         # Truncate prompt preview
         preview = s.prompt_preview[:25] if s.prompt_preview else ""

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -323,3 +323,49 @@ class TestFormatDuration:
         started = time.time() - 24 * 60 * 60
         result = format_duration(started)
         assert result == "1d"
+
+
+class TestFormatProjectDisplay:
+    """Tests for format_project_display handling worktrees."""
+
+    def test_regular_path(self):
+        """Regular path returns last component."""
+        from cdash.components.sessions import format_project_display
+
+        result = format_project_display("/Users/toli/code/my-project")
+        assert result == "my-project"
+
+    def test_worktree_path(self):
+        """Worktree path returns parent#worktree format."""
+        from cdash.components.sessions import format_project_display
+
+        result = format_project_display("/Users/toli/code/claude-dashboard/.worktrees/8")
+        assert result == "claude-dashboard#8"
+
+    def test_worktree_with_subpath(self):
+        """Worktree path with subdirectory still extracts correctly."""
+        from cdash.components.sessions import format_project_display
+
+        result = format_project_display("/Users/toli/code/project/.worktrees/123/src")
+        assert result == "project#123"
+
+    def test_none_returns_unknown(self):
+        """None project name returns 'unknown'."""
+        from cdash.components.sessions import format_project_display
+
+        result = format_project_display(None)
+        assert result == "unknown"
+
+    def test_empty_string_returns_unknown(self):
+        """Empty string returns 'unknown'."""
+        from cdash.components.sessions import format_project_display
+
+        result = format_project_display("")
+        assert result == "unknown"
+
+    def test_hyphenated_project_name(self):
+        """Hyphenated project names are preserved."""
+        from cdash.components.sessions import format_project_display
+
+        result = format_project_display("/path/to/my-cool-project")
+        assert result == "my-cool-project"


### PR DESCRIPTION
## Summary
- Worktree sessions now display as `project#8` instead of just `8`
- Added `format_project_display()` helper that detects `/.worktrees/` in path
- Extracts parent project name and worktree identifier

## Test plan
- [x] New tests for `format_project_display` covering regular paths, worktrees, edge cases
- [x] All 190 tests passing

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)