### PR TITLE
feat(ui): replace refresh timestamps with liveness indicator dots

### DIFF
--- a/src/cdash/app.tcss
+++ b/src/cdash/app.tcss
@@ -75,22 +75,11 @@ TodayHeader > .spacer {
     width: 1fr;
 }
 
-TodayHeader > .refresh-info,
-TodayHeader > RefreshIndicator {
-    color: $text-muted;
-    width: auto;
-    text-align: right;
-}
-
 /* ============================================
-   REFRESH INDICATORS
+   LIVENESS INDICATORS (Refresh dots)
    ============================================ */
 
-RefreshIndicator {
-    color: $text-muted;
-    width: auto;
-    text-align: right;
-}
+/* RefreshIndicator styles are in DEFAULT_CSS in indicators.py */
 
 .header-spacer {
     width: 1fr;

--- a/src/cdash/components/header.py
+++ b/src/cdash/components/header.py
@@ -1,6 +1,4 @@
-"""TodayHeader widget showing big numbers and refresh info."""
-
-import time
+"""TodayHeader widget showing big numbers and liveness indicator."""
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal
@@ -11,14 +9,13 @@ from cdash.theme import CORAL
 
 
 class TodayHeader(Horizontal):
-    """Big numbers showing today's totals and refresh info."""
+    """Big numbers showing today's totals and liveness dot."""
 
     def __init__(self) -> None:
         super().__init__()
         self._msgs = 0
         self._tools = 0
         self._active = 0
-        self._last_refresh = 0.0
 
     def compose(self) -> ComposeResult:
         yield Static("TODAY", classes="header-title")
@@ -43,7 +40,6 @@ class TodayHeader(Horizontal):
 
     def mark_refreshed(self) -> None:
         """Mark data as just refreshed."""
-        self._last_refresh = time.time()
         try:
             indicator = self.query_one("#refresh-info", RefreshIndicator)
             indicator.mark_refreshed()
@@ -63,14 +59,3 @@ class TodayHeader(Horizontal):
         except Exception:
             # Widget may not be mounted yet
             pass
-
-    def _format_refresh_ago(self) -> str:
-        """Format time since last refresh as human-readable."""
-        if self._last_refresh == 0:
-            return "never"
-
-        elapsed = int(time.time() - self._last_refresh)
-        if elapsed < 60:
-            return f"refreshed {elapsed}s ago"
-        mins = elapsed // 60
-        return f"refreshed {mins}m ago"

--- a/src/cdash/components/indicators.py
+++ b/src/cdash/components/indicators.py
@@ -1,55 +1,134 @@
-"""Refresh indicator widgets for auto-updating panels."""
+"""Liveness indicator widgets for auto-updating panels."""
 
 import time
+from enum import Enum
 
 from textual.widgets import Static
 
 
-class RefreshIndicator(Static):
-    """Auto-updating timestamp indicator.
+class LivenessState(Enum):
+    """States for the liveness indicator."""
 
-    Shows "↻ Xs ago" and updates every second via CSS animation trick.
+    INIT = "init"  # Not yet refreshed
+    LIVE = "live"  # Recently refreshed, all good
+    REFRESHING = "refreshing"  # Currently refreshing (brief animation)
+    WARN = "warn"  # Missed 1-2 refresh cycles
+    ERROR = "error"  # Missed 3+ refresh cycles
+
+
+# Thresholds in seconds (assuming 10s refresh interval)
+WARN_THRESHOLD = 25  # ~2 missed cycles
+ERROR_THRESHOLD = 45  # ~4 missed cycles
+REFRESHING_DURATION = 0.5  # How long to show refreshing state
+
+
+class RefreshIndicator(Static):
+    """Minimal liveness indicator dot.
+
+    Shows a simple dot that changes color based on refresh health:
+    - init: dim dot (...)
+    - live: green dot (●)
+    - refreshing: pulsing coral dot (◉) - brief animation
+    - warn: amber dot (●)
+    - error: red dot (●)
+
     Parent widget should call mark_refreshed() when data is fetched.
+    """
+
+    DEFAULT_CSS = """
+    RefreshIndicator {
+        width: 3;
+        text-align: right;
+    }
+    RefreshIndicator.init {
+        color: #555555;
+    }
+    RefreshIndicator.live {
+        color: #4a9f4a;
+    }
+    RefreshIndicator.refreshing {
+        color: #e07850;
+        text-style: bold;
+    }
+    RefreshIndicator.warn {
+        color: #d4a017;
+    }
+    RefreshIndicator.error {
+        color: #cc4444;
+    }
     """
 
     def __init__(self, id: str | None = None) -> None:
         super().__init__("", id=id)
         self._last_refresh: float = 0.0
+        self._state = LivenessState.INIT
         self._update_timer = None
+        self._refreshing_until: float = 0.0
 
     def on_mount(self) -> None:
         """Start the update timer when mounted."""
-        # Update every second to keep the time display fresh
-        self._update_timer = self.set_interval(1.0, self._tick)
+        self._update_timer = self.set_interval(0.5, self._tick)
+        self._update_display()
 
     def mark_refreshed(self) -> None:
-        """Mark data as just refreshed."""
+        """Mark data as just refreshed - triggers brief animation."""
         self._last_refresh = time.time()
+        self._refreshing_until = self._last_refresh + REFRESHING_DURATION
+        self._state = LivenessState.REFRESHING
         self._update_display()
 
     def _tick(self) -> None:
-        """Called every second to update display."""
-        self._update_display()
+        """Called periodically to update state."""
+        now = time.time()
+
+        # Check if we're still in refreshing animation
+        if self._refreshing_until > now:
+            if self._state != LivenessState.REFRESHING:
+                self._state = LivenessState.REFRESHING
+                self._update_display()
+            return
+
+        # Determine state based on staleness
+        if self._last_refresh == 0:
+            new_state = LivenessState.INIT
+        else:
+            elapsed = now - self._last_refresh
+            if elapsed < WARN_THRESHOLD:
+                new_state = LivenessState.LIVE
+            elif elapsed < ERROR_THRESHOLD:
+                new_state = LivenessState.WARN
+            else:
+                new_state = LivenessState.ERROR
+
+        if new_state != self._state:
+            self._state = new_state
+            self._update_display()
 
     def _update_display(self) -> None:
-        """Update the displayed time."""
-        self.update(f"↻ {self._format_refresh_ago()}")
+        """Update the displayed dot and CSS class."""
+        # Remove old state classes
+        for state in LivenessState:
+            self.remove_class(state.value)
 
-    def _format_refresh_ago(self) -> str:
-        """Format time since last refresh as human-readable."""
-        if self._last_refresh == 0:
-            return "..."
+        # Add current state class
+        self.add_class(self._state.value)
 
-        elapsed = int(time.time() - self._last_refresh)
-        if elapsed < 60:
-            return f"{elapsed}s"
-        mins = elapsed // 60
-        if mins < 60:
-            return f"{mins}m"
-        hours = mins // 60
-        return f"{hours}h"
+        # Choose dot character
+        if self._state == LivenessState.INIT:
+            dot = "·"
+        elif self._state == LivenessState.REFRESHING:
+            dot = "◉"
+        else:
+            dot = "●"
+
+        self.update(dot)
 
     @property
     def last_refresh(self) -> float:
         """Get the timestamp of last refresh."""
         return self._last_refresh
+
+    @property
+    def state(self) -> LivenessState:
+        """Get the current liveness state."""
+        return self._state

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,7 +1,5 @@
 """Tests for TodayHeader widget."""
 
-import time
-
 import pytest
 
 from cdash.components.header import TodayHeader
@@ -28,28 +26,9 @@ class TestTodayHeader:
         assert header._active == 3
 
     @pytest.mark.asyncio
-    async def test_header_refresh_info(self):
-        """TodayHeader shows refresh timestamp."""
+    async def test_header_has_mark_refreshed(self):
+        """TodayHeader has mark_refreshed method."""
         header = TodayHeader()
-        header.mark_refreshed()
-
-        # Should have recent timestamp
-        assert header._last_refresh > 0
-        assert time.time() - header._last_refresh < 5
-
-    @pytest.mark.asyncio
-    async def test_format_refresh_ago(self):
-        """format_refresh_ago shows human-readable time."""
-        header = TodayHeader()
-
-        # Just refreshed
-        header._last_refresh = time.time()
-        assert "0s" in header._format_refresh_ago()
-
-        # 30 seconds ago
-        header._last_refresh = time.time() - 30
-        assert "30s" in header._format_refresh_ago()
-
-        # 2 minutes ago
-        header._last_refresh = time.time() - 120
-        assert "2m" in header._format_refresh_ago()
+        # Should not raise - delegates to child RefreshIndicator
+        assert hasattr(header, "mark_refreshed")
+        assert callable(header.mark_refreshed)


### PR DESCRIPTION
## Summary
- Replace verbose "↻ Xs ago" timestamps with minimal colored dots
- 5 states: init (dim) → live (green) → refreshing (coral pulse) → warn (amber) → error (red)
- Thresholds: warn at 25s, error at 45s stale

Much less visual noise while still indicating system health at a glance.

## Test plan
- [x] All 190 tests pass
- [x] Visual verification via screenshot
- [ ] Manual testing: watch dots transition through states

## TODOs (follow-up)
- [ ] **Slow app startup** - test suite takes 4+ minutes, app itself feels sluggish on launch
- [ ] **Add responsiveness test** - unit test ensuring app renders within X ms threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)