### PR TITLE
feat(sessions): rich session cards with collapsible stats

### DIFF
--- a/src/cdash/app.py
+++ b/src/cdash/app.py
@@ -70,6 +70,7 @@ class ClaudeDashApp(App):
     BINDINGS = [
         ("q", "quit", "Quit"),
         ("r", "relaunch", "Reload"),
+        ("s", "toggle_stats", "Stats"),
         ("1", "switch_tab('tab-overview')", "Overview"),
         ("2", "switch_tab('tab-github')", "GitHub"),
         ("3", "switch_tab('tab-plugins')", "Plugins"),
@@ -182,6 +183,16 @@ class ClaudeDashApp(App):
         """Switch to a specific tab."""
         tabs = self.query_one(DashboardTabs)
         tabs.active = tab_id
+
+    def action_toggle_stats(self) -> None:
+        """Toggle the stats collapsible panel."""
+        from textual.widgets import Collapsible
+
+        try:
+            collapsible = self.query_one("#stats-collapsible", Collapsible)
+            collapsible.collapsed = not collapsible.collapsed
+        except Exception:
+            pass
 
     async def action_quit(self) -> None:
         """Quit the application."""

--- a/src/cdash/app.tcss
+++ b/src/cdash/app.tcss
@@ -142,9 +142,90 @@ ActiveSessionsPanel > SessionItem:hover {
     background: $panel;
 }
 
-ActiveSessionsPanel > .no-sessions {
+ActiveSessionsPanel > .no-sessions,
+SessionCardContainer > .no-sessions {
     color: $text-muted;
     text-style: italic;
+    padding: 1;
+}
+
+/* Session Card Container */
+SessionCardContainer {
+    height: auto;
+    max-height: 30;
+    padding: 0;
+}
+
+/* Session Cards */
+SessionCard {
+    height: auto;
+    padding: 1;
+    margin: 0 0 1 0;
+    background: $surface;
+    border: round #333333;
+}
+
+SessionCard:focus {
+    border: round $primary;
+}
+
+SessionCard.active {
+    border: round $success;
+}
+
+SessionCard.idle {
+    border: round $warning;
+}
+
+SessionCard > .card-header {
+    height: 1;
+    width: 100%;
+}
+
+SessionCard > .card-branch {
+    height: 1;
+    color: $text-muted;
+}
+
+SessionCard > .card-divider {
+    height: 1;
+    color: #444444;
+}
+
+SessionCard > .card-prompt {
+    height: auto;
+    max-height: 3;
+    padding: 0;
+}
+
+SessionCard > .card-tool {
+    height: 1;
+}
+
+SessionCard > .card-footer {
+    height: 1;
+    width: 100%;
+}
+
+/* ============================================
+   COLLAPSIBLE (Stats & Trends)
+   ============================================ */
+
+#stats-collapsible {
+    margin: 0 1;
+    background: $panel;
+    border: round #333333;
+}
+
+#stats-collapsible > CollapsibleTitle {
+    color: $secondary;
+    text-style: bold;
+    background: $surface;
+    padding: 0 1;
+}
+
+#stats-collapsible > Contents {
+    padding: 0;
 }
 
 /* ============================================

--- a/src/cdash/components/sessions.py
+++ b/src/cdash/components/sessions.py
@@ -1,12 +1,13 @@
 """Active sessions widget for displaying Claude Code sessions."""
 
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widget import Widget
 from textual.widgets import Static
 
 from cdash.components.indicators import RefreshIndicator
 from cdash.data.sessions import Session, format_duration, load_all_sessions
-from cdash.theme import AMBER, GREEN
+from cdash.theme import AMBER, GREEN, TEXT_MUTED
 
 
 def format_project_display(project_name: str | None) -> str:
@@ -28,7 +29,7 @@ def format_project_display(project_name: str | None) -> str:
 
 
 class SessionItem(Static):
-    """A single session item in the list."""
+    """A single session item in the list (legacy, kept for compatibility)."""
 
     def __init__(self, session: Session) -> None:
         super().__init__()
@@ -67,6 +68,170 @@ class SessionItem(Static):
         return f'{status} {project_display:<16} "{preview}" {tool} {duration}'
 
 
+class SessionCard(Widget, can_focus=True):
+    """Multi-line session card with rich information display."""
+
+    DEFAULT_CSS = """
+    SessionCard {
+        height: auto;
+        padding: 1;
+        margin: 0 0 1 0;
+        background: $surface;
+        border: round #333333;
+    }
+    SessionCard:focus {
+        border: round $primary;
+    }
+    SessionCard.active {
+        border: round $success;
+    }
+    SessionCard.idle {
+        border: round $warning;
+    }
+    SessionCard > .card-header {
+        height: 1;
+        width: 100%;
+    }
+    SessionCard > .card-branch {
+        height: 1;
+        color: $text-muted;
+    }
+    SessionCard > .card-divider {
+        height: 1;
+        color: #444444;
+    }
+    SessionCard > .card-prompt {
+        height: auto;
+        max-height: 3;
+        padding: 0;
+    }
+    SessionCard > .card-tool {
+        height: 1;
+    }
+    SessionCard > .card-footer {
+        height: 1;
+        width: 100%;
+    }
+    """
+
+    def __init__(self, session: Session) -> None:
+        super().__init__()
+        self.session = session
+        # Add CSS class based on session state
+        if session.is_active:
+            self.add_class("active")
+        elif session.is_idle:
+            self.add_class("idle")
+
+    def compose(self) -> ComposeResult:
+        """Build the card layout."""
+        s = self.session
+
+        # Header: status + project name + badge + duration
+        yield Static(self._render_header(), classes="card-header")
+
+        # Branch line (if available)
+        if s.git_branch:
+            yield Static(f"[{TEXT_MUTED}]branch: {s.git_branch}[/]", classes="card-branch")
+
+        # Divider
+        yield Static("[#444444]" + "─" * 60 + "[/]", classes="card-divider")
+
+        # Prompt preview (2 lines max, full prompt on expand)
+        prompt_text = self._format_prompt()
+        yield Static(prompt_text, classes="card-prompt")
+
+        # Divider
+        yield Static("[#444444]" + "─" * 60 + "[/]", classes="card-divider")
+
+        # Current tool with context (if active)
+        tool_text = self._render_tool()
+        if tool_text:
+            yield Static(tool_text, classes="card-tool")
+
+        # Footer: recent tools + stats
+        yield Static(self._render_footer(), classes="card-footer")
+
+    def _render_header(self) -> str:
+        """Render the card header line."""
+        s = self.session
+
+        # Status indicator
+        if s.is_active:
+            status = f"[bold {GREEN}]●[/]"
+            badge = f"[bold {GREEN}][ACTIVE][/]"
+        elif s.is_idle:
+            import time
+
+            status = f"[bold {AMBER}]◐[/]"
+            idle_mins = int((time.time() - s.last_modified) // 60)
+            badge = f"[{AMBER}][IDLE {idle_mins}m][/]"
+        else:
+            status = "[dim]○[/]"
+            badge = ""
+
+        # Project name
+        project_display = format_project_display(s.project_name)
+
+        # Duration
+        duration = ""
+        dur = format_duration(s.started_at)
+        if dur:
+            duration = f"⏱ {dur}"
+
+        # Build header with proper spacing
+        left = f"{status} [bold]{project_display}[/]"
+        right = f"{badge} {duration}".strip()
+
+        return f"{left:<40} {right:>30}"
+
+    def _format_prompt(self) -> str:
+        """Format the prompt preview (2 lines)."""
+        s = self.session
+        if not s.full_prompt:
+            return f"[{TEXT_MUTED}](no prompt)[/]"
+
+        # Show first ~120 chars across 2 lines
+        prompt = s.full_prompt.replace("\n", " ").strip()
+        if len(prompt) > 120:
+            prompt = prompt[:117] + "..."
+
+        return f'[italic]"{prompt}"[/]'
+
+    def _render_tool(self) -> str:
+        """Render current tool with context."""
+        s = self.session
+        if not s.current_tool:
+            return ""
+
+        tool_display = f"[bold]⚙ {s.current_tool}[/]"
+        if s.current_tool_input:
+            # Truncate long paths/commands
+            input_display = s.current_tool_input
+            if len(input_display) > 50:
+                input_display = "..." + input_display[-47:]
+            tool_display += f" [{TEXT_MUTED}]{input_display}[/]"
+
+        return tool_display
+
+    def _render_footer(self) -> str:
+        """Render the footer with recent tools and stats."""
+        s = self.session
+
+        # Recent tools chain (left side)
+        if s.recent_tools:
+            chain = "→".join(s.recent_tools)
+            recent = f"[{TEXT_MUTED}]Recent: {chain}[/]"
+        else:
+            recent = ""
+
+        # Stats (right side)
+        stats = f"[{TEXT_MUTED}]📊 {s.message_count} msgs, {s.tool_count} tools[/]"
+
+        # Pad to fill width
+        return f"{recent:<45} {stats:>25}"
+
+
 class SessionsHeader(Horizontal):
     """Header with title and refresh indicator."""
 
@@ -76,46 +241,61 @@ class SessionsHeader(Horizontal):
         yield RefreshIndicator(id="sessions-refresh")
 
 
+class SessionCardContainer(VerticalScroll):
+    """Scrollable container for session cards."""
+
+    DEFAULT_CSS = """
+    SessionCardContainer {
+        height: auto;
+        max-height: 25;
+    }
+    """
+
+
 class ActiveSessionsPanel(Vertical):
-    """Panel displaying active sessions."""
+    """Panel displaying active sessions with rich cards."""
 
     def compose(self) -> ComposeResult:
         """Compose the panel."""
         yield SessionsHeader()
-        yield from self._build_session_items()
+        with SessionCardContainer():
+            yield from self._build_session_cards()
 
-    def _build_session_items(self) -> list[Static]:
-        """Build session item widgets."""
-        # Get all sessions (active ones will show with ● indicator)
+    def _build_session_cards(self) -> list[Widget]:
+        """Build session card widgets."""
+        # Get all sessions
         sessions = load_all_sessions()
 
         if not sessions:
-            return [Static("No sessions found", classes="no-sessions")]
+            return [Static("No active sessions", classes="no-sessions")]
 
-        # Show active sessions first, then recent inactive ones (up to 5 total)
+        # Only show active and idle sessions (green/yellow)
         active = [s for s in sessions if s.is_active]
-        inactive = [s for s in sessions if not s.is_active]
+        idle = [s for s in sessions if s.is_idle]
 
-        items = []
-        for session in active[:5]:
-            items.append(SessionItem(session))
+        # Combine: active first, then idle (max 10 total)
+        combined = active[:7] + idle[: 10 - len(active[:7])]
 
-        # Fill remaining slots with inactive sessions
-        remaining = 5 - len(items)
-        for session in inactive[:remaining]:
-            items.append(SessionItem(session))
+        if not combined:
+            return [Static("No active sessions", classes="no-sessions")]
 
-        return items
+        return [SessionCard(session) for session in combined]
 
     def refresh_sessions(self) -> None:
         """Refresh the sessions list."""
-        # Remove old items
-        for widget in self.query("SessionItem, .no-sessions"):
+        # Find the container
+        try:
+            container = self.query_one(SessionCardContainer)
+        except Exception:
+            return
+
+        # Remove old cards
+        for widget in container.query("SessionCard, .no-sessions"):
             widget.remove()
 
-        # Add new items
-        for item in self._build_session_items():
-            self.mount(item)
+        # Add new cards
+        for card in self._build_session_cards():
+            container.mount(card)
 
         # Mark refresh indicator
         try:

--- a/src/cdash/components/tabs.py
+++ b/src/cdash/components/tabs.py
@@ -2,7 +2,7 @@
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Static, TabbedContent, TabPane
+from textual.widgets import Collapsible, Static, TabbedContent, TabPane
 
 from cdash.components.agents import AgentsTab
 from cdash.components.ci import CIActivityPanel, CITab
@@ -32,9 +32,10 @@ class OverviewTab(Vertical):
     def compose(self) -> ComposeResult:
         yield TodayHeader()
         yield ActiveSessionsPanel()
-        yield StatsPanel()
-        yield ToolBreakdownPanel()
-        yield CIActivityPanel()
+        with Collapsible(title="Stats & Trends", collapsed=True, id="stats-collapsible"):
+            yield StatsPanel()
+            yield ToolBreakdownPanel()
+            yield CIActivityPanel()
 
     def refresh_data(
         self,

--- a/tests/test_session_card.py
+++ b/tests/test_session_card.py
@@ -1,0 +1,186 @@
+"""Tests for the SessionCard widget."""
+
+import time
+
+import pytest
+
+from cdash.app import ClaudeDashApp
+from cdash.components.sessions import SessionCard, format_project_display
+from cdash.data.sessions import Session
+
+
+def make_session(
+    project_name: str = "/test/project",
+    is_active: bool = True,
+    is_idle: bool = False,
+    prompt: str = "Test prompt",
+    current_tool: str | None = None,
+    current_tool_input: str = "",
+    git_branch: str = "",
+    message_count: int = 5,
+    tool_count: int = 10,
+    recent_tools: list[str] | None = None,
+) -> Session:
+    """Create a test session with configurable properties."""
+    now = time.time()
+    if is_active:
+        last_modified = now  # Active = modified in last 60s
+    elif is_idle:
+        last_modified = now - 120  # Idle = 60s-5min ago
+    else:
+        last_modified = now - 600  # Inactive = older than 5min
+
+    return Session(
+        session_id="test-session",
+        project_path="/test/project",
+        project_name=project_name,
+        cwd="/test/project",
+        last_modified=last_modified,
+        prompt_preview=prompt[:50] + "..." if len(prompt) > 50 else prompt,
+        current_tool=current_tool if is_active else None,
+        is_active=is_active,
+        started_at=now - 1800,  # 30 min ago
+        git_branch=git_branch,
+        message_count=message_count,
+        tool_count=tool_count,
+        recent_tools=recent_tools or [],
+        current_tool_input=current_tool_input if is_active else "",
+        full_prompt=prompt,
+    )
+
+
+class TestSessionCard:
+    """Tests for SessionCard widget."""
+
+    def test_session_card_has_active_class(self):
+        """Active session card has 'active' CSS class."""
+        session = make_session(is_active=True)
+        card = SessionCard(session)
+        assert "active" in card.classes
+
+    def test_session_card_has_idle_class(self):
+        """Idle session card has 'idle' CSS class."""
+        session = make_session(is_active=False, is_idle=True)
+        card = SessionCard(session)
+        assert "idle" in card.classes
+
+    def test_session_card_no_special_class_when_inactive(self):
+        """Inactive session has no active/idle class."""
+        session = make_session(is_active=False, is_idle=False)
+        card = SessionCard(session)
+        assert "active" not in card.classes
+        assert "idle" not in card.classes
+
+    def test_render_header_active_session(self):
+        """Header renders correctly for active session."""
+        session = make_session(is_active=True, project_name="/path/to/myproject")
+        card = SessionCard(session)
+        header = card._render_header()
+        assert "myproject" in header
+        assert "[ACTIVE]" in header
+
+    def test_render_header_idle_session(self):
+        """Header renders correctly for idle session."""
+        session = make_session(is_active=False, is_idle=True)
+        card = SessionCard(session)
+        header = card._render_header()
+        assert "[IDLE" in header
+
+    def test_render_tool_with_file_path(self):
+        """Tool renders with file path input."""
+        session = make_session(
+            is_active=True,
+            current_tool="Read",
+            current_tool_input="/src/main.py",
+        )
+        card = SessionCard(session)
+        tool = card._render_tool()
+        assert "Read" in tool
+        assert "/src/main.py" in tool
+
+    def test_render_tool_truncates_long_input(self):
+        """Long tool input is truncated."""
+        long_path = "/very/long/path/to/some/deeply/nested/file/in/project.py"
+        session = make_session(
+            is_active=True,
+            current_tool="Read",
+            current_tool_input=long_path,
+        )
+        card = SessionCard(session)
+        tool = card._render_tool()
+        assert "..." in tool  # Should have truncation indicator
+        assert len(tool) < len(long_path) + 50  # Should be truncated
+
+    def test_render_tool_empty_when_no_tool(self):
+        """No tool output when session has no current tool."""
+        session = make_session(is_active=True, current_tool=None)
+        card = SessionCard(session)
+        tool = card._render_tool()
+        assert tool == ""
+
+    def test_render_footer_with_recent_tools(self):
+        """Footer shows recent tools chain."""
+        session = make_session(recent_tools=["Read", "Edit", "Bash"])
+        card = SessionCard(session)
+        footer = card._render_footer()
+        assert "Recent:" in footer
+        assert "Read" in footer
+        assert "Edit" in footer
+        assert "Bash" in footer
+
+    def test_render_footer_with_stats(self):
+        """Footer shows message and tool counts."""
+        session = make_session(message_count=15, tool_count=42)
+        card = SessionCard(session)
+        footer = card._render_footer()
+        assert "15 msgs" in footer
+        assert "42 tools" in footer
+
+    def test_format_prompt_truncates_long_prompt(self):
+        """Long prompts are truncated."""
+        long_prompt = "This is a very long prompt " * 10
+        session = make_session(prompt=long_prompt)
+        card = SessionCard(session)
+        formatted = card._format_prompt()
+        assert "..." in formatted
+        assert len(formatted) < len(long_prompt)
+
+    def test_format_prompt_no_prompt(self):
+        """Shows placeholder when no prompt."""
+        session = make_session(prompt="")
+        card = SessionCard(session)
+        formatted = card._format_prompt()
+        assert "(no prompt)" in formatted
+
+
+class TestSessionCardIntegration:
+    """Integration tests for SessionCard in the app."""
+
+    @pytest.mark.asyncio
+    async def test_session_card_renders_in_app(self):
+        """Session card renders without errors in the app."""
+        app = ClaudeDashApp()
+        async with app.run_test():
+            # App should load without errors even with real session data
+            from cdash.components.sessions import ActiveSessionsPanel
+
+            panel = app.query_one(ActiveSessionsPanel)
+            assert panel is not None
+
+    @pytest.mark.asyncio
+    async def test_session_card_focusable(self):
+        """Session cards should be focusable."""
+        from cdash.components.sessions import SessionCardContainer
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            # Try to find cards if any exist
+            try:
+                container = app.query_one(SessionCardContainer)
+                cards = container.query("SessionCard")
+                if cards:
+                    # Cards should be focusable
+                    assert cards.first().can_focus is True
+            except Exception:
+                # No cards is fine, just testing the widget can work
+                pass

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -198,6 +198,8 @@ class TestTabsRender:
     @pytest.mark.asyncio
     async def test_overview_has_visible_content(self):
         """Overview tab has visible panels."""
+        from textual.widgets import Collapsible
+
         from cdash.components.sessions import ActiveSessionsPanel
         from cdash.components.stats import StatsPanel
         from cdash.components.tools import ToolBreakdownPanel
@@ -205,10 +207,16 @@ class TestTabsRender:
         app = ClaudeDashApp()
         async with app.run_test():
             overview = app.query_one(OverviewTab)
-            # All three panels should exist and have height
+            # Sessions panel should be visible
             sessions = overview.query_one(ActiveSessionsPanel)
+            assert sessions.size.height > 0
+
+            # Stats and tools are inside a collapsible (collapsed by default)
+            collapsible = overview.query_one("#stats-collapsible", Collapsible)
+            assert collapsible.collapsed is True
+
+            # Panels exist inside collapsible
             stats = overview.query_one(StatsPanel)
             tools = overview.query_one(ToolBreakdownPanel)
-            assert sessions.size.height > 0
-            assert stats.size.height > 0
-            assert tools.size.height > 0
+            assert stats is not None
+            assert tools is not None


### PR DESCRIPTION
## Summary
- Replace single-line session items with rich multi-line cards
- Cards show: project name, status, duration, branch, prompt preview, current tool context, recent tools chain, and stats
- Stats/Tools/CI panels now collapsible (default collapsed, toggle with `s` key)
- Session cards are focusable for keyboard navigation

## Test plan
- [x] All 210 tests pass
- [x] Run `python -m cdash` to visually verify cards
- [x] Test `s` key toggles stats panel
- [x] Test keyboard navigation between cards

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)