### PR TITLE
feat(overview): add host resource stats (#20)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 dependencies = [
     "textual>=0.47.0",
     "rich>=13.0.0",
+    "psutil>=5.9.0",
 ]
 
 [project.optional-dependencies]

--- a/src/cdash/components/resources.py
+++ b/src/cdash/components/resources.py
@@ -1,0 +1,58 @@
+"""Resource stats widget showing CPU/memory for Claude processes."""
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Static
+
+from cdash.data.resources import get_resource_stats
+from cdash.theme import BLUE, CORAL
+
+
+class ResourceStatsWidget(Horizontal):
+    """Compact widget showing CPU and memory usage for Claude processes."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cpu = 0.0
+        self._mem_mb = 0.0
+        self._mem_pct = 0.0
+        self._proc_count = 0
+
+    def compose(self) -> ComposeResult:
+        yield Static("HOST", classes="header-title")
+        yield Static("", id="cpu-stat", classes="stat-block")
+        yield Static("", id="mem-stat", classes="stat-block")
+        yield Static("", id="proc-stat", classes="stat-block")
+
+    def refresh_stats(self) -> None:
+        """Refresh resource stats from psutil."""
+        stats = get_resource_stats()
+        self._cpu = stats.cpu_percent
+        self._mem_mb = stats.memory_mb
+        self._mem_pct = stats.memory_percent
+        self._proc_count = stats.process_count
+        self._update_display()
+
+    def _update_display(self) -> None:
+        """Update all display widgets."""
+        try:
+            cpu_widget = self.query_one("#cpu-stat", Static)
+            mem_widget = self.query_one("#mem-stat", Static)
+            proc_widget = self.query_one("#proc-stat", Static)
+
+            # Format CPU (cap display at 999%)
+            cpu_display = min(self._cpu, 999)
+            cpu_widget.update(f"[{CORAL} bold]{cpu_display:.0f}%[/] cpu")
+
+            # Format memory (show MB if under 1GB, else GB)
+            if self._mem_mb >= 1024:
+                mem_display = f"{self._mem_mb / 1024:.1f}GB"
+            else:
+                mem_display = f"{self._mem_mb:.0f}MB"
+            mem_widget.update(f"[{CORAL} bold]{mem_display}[/] ram")
+
+            # Process count
+            proc_word = "proc" if self._proc_count == 1 else "procs"
+            proc_widget.update(f"[{BLUE}]{self._proc_count}[/] {proc_word}")
+        except Exception:
+            pass

--- a/src/cdash/components/tabs.py
+++ b/src/cdash/components/tabs.py
@@ -8,6 +8,7 @@ from cdash.components.ci import CIActivityPanel, CITab
 from cdash.components.header import TodayHeader
 from cdash.components.mcp import MCPServersTab
 from cdash.components.plugins import PluginsTab
+from cdash.components.resources import ResourceStatsWidget
 from cdash.components.sessions import ActiveSessionsPanel
 from cdash.components.stats import StatsPanel
 from cdash.components.tools import ToolBreakdownPanel
@@ -69,6 +70,7 @@ class OverviewContent(Vertical):
 
     def compose(self) -> ComposeResult:
         yield TodayHeader()
+        yield ResourceStatsWidget()
         yield ActiveSessionsPanel()
         with Collapsible(title="Stats & Trends", collapsed=True, id="stats-collapsible"):
             yield StatsPanel()
@@ -128,6 +130,11 @@ class OverviewTab(Vertical):
             header = content.query_one(TodayHeader)
             header.update_stats(msgs=msgs_today, tools=tools_today, active=active_count)
             header.mark_refreshed()
+        except Exception:
+            pass
+        try:
+            content = self.query_one(OverviewContent)
+            content.query_one(ResourceStatsWidget).refresh_stats()
         except Exception:
             pass
         try:

--- a/src/cdash/data/resources.py
+++ b/src/cdash/data/resources.py
@@ -1,0 +1,100 @@
+"""Resource stats for Claude processes using psutil."""
+
+import time
+from dataclasses import dataclass
+
+import psutil
+
+# Cache for resource stats (sampling CPU needs time between calls)
+_resources_cache: "ResourceStats | None" = None
+_resources_cache_time: float = 0
+_CACHE_TTL = 2.0  # seconds
+
+
+@dataclass
+class ResourceStats:
+    """Aggregate resource usage for all Claude processes."""
+
+    process_count: int
+    cpu_percent: float  # combined CPU across all processes
+    memory_mb: float  # combined memory in MB
+    memory_percent: float  # combined memory as % of system RAM
+
+
+def find_claude_processes() -> list[psutil.Process]:
+    """Find all Claude-related processes.
+
+    Looks for processes named 'claude' or with 'claude' in cmdline.
+
+    Returns:
+        List of psutil.Process objects
+    """
+    claude_procs = []
+
+    for proc in psutil.process_iter(["name", "cmdline"]):
+        try:
+            name = proc.info.get("name", "").lower()
+            cmdline = proc.info.get("cmdline") or []
+
+            # Match process name
+            if "claude" in name:
+                claude_procs.append(proc)
+                continue
+
+            # Match command line (e.g., 'node /path/to/claude')
+            for arg in cmdline:
+                if isinstance(arg, str) and "claude" in arg.lower():
+                    claude_procs.append(proc)
+                    break
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+
+    return claude_procs
+
+
+def get_resource_stats(use_cache: bool = True) -> ResourceStats:
+    """Get aggregate resource stats for all Claude processes.
+
+    Args:
+        use_cache: If True, return cached data if fresh
+
+    Returns:
+        ResourceStats with combined CPU/memory usage
+    """
+    global _resources_cache, _resources_cache_time
+
+    # Return cached data if fresh
+    if use_cache and _resources_cache is not None:
+        if time.time() - _resources_cache_time < _CACHE_TTL:
+            return _resources_cache
+
+    procs = find_claude_processes()
+    total_cpu = 0.0
+    total_memory_bytes = 0
+
+    for proc in procs:
+        try:
+            # cpu_percent needs to be called twice with interval or cached
+            # Here we get non-blocking measurement (since we refresh frequently)
+            total_cpu += proc.cpu_percent(interval=None)
+            mem_info = proc.memory_info()
+            total_memory_bytes += mem_info.rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+
+    total_memory_mb = total_memory_bytes / (1024 * 1024)
+    total_mem = psutil.virtual_memory()
+    memory_percent = (total_memory_bytes / total_mem.total) * 100 if total_mem.total else 0
+
+    stats = ResourceStats(
+        process_count=len(procs),
+        cpu_percent=total_cpu,
+        memory_mb=total_memory_mb,
+        memory_percent=memory_percent,
+    )
+
+    # Update cache
+    _resources_cache = stats
+    _resources_cache_time = time.time()
+
+    return stats

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,143 @@
+"""Tests for resource stats data loading and display."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cdash.data.resources import ResourceStats, find_claude_processes, get_resource_stats
+
+
+class TestResourceStats:
+    """Tests for ResourceStats dataclass."""
+
+    def test_creates_resource_stats(self):
+        """Can create a ResourceStats instance."""
+        stats = ResourceStats(
+            process_count=2,
+            cpu_percent=25.5,
+            memory_mb=512.0,
+            memory_percent=4.2,
+        )
+        assert stats.process_count == 2
+        assert stats.cpu_percent == 25.5
+        assert stats.memory_mb == 512.0
+        assert stats.memory_percent == 4.2
+
+
+class TestFindClaudeProcesses:
+    """Tests for finding Claude processes."""
+
+    def test_finds_process_by_name(self):
+        """Finds processes with 'claude' in name."""
+        mock_proc = MagicMock()
+        mock_proc.info = {"name": "claude", "cmdline": []}
+
+        with patch("cdash.data.resources.psutil.process_iter", return_value=[mock_proc]):
+            procs = find_claude_processes()
+            assert len(procs) == 1
+            assert procs[0] == mock_proc
+
+    def test_finds_process_by_cmdline(self):
+        """Finds processes with 'claude' in command line."""
+        mock_proc = MagicMock()
+        mock_proc.info = {"name": "node", "cmdline": ["/usr/local/bin/node", "/path/to/claude"]}
+
+        with patch("cdash.data.resources.psutil.process_iter", return_value=[mock_proc]):
+            procs = find_claude_processes()
+            assert len(procs) == 1
+
+    def test_skips_unrelated_processes(self):
+        """Skips processes without 'claude' in name or cmdline."""
+        mock_proc = MagicMock()
+        mock_proc.info = {"name": "python", "cmdline": ["python", "script.py"]}
+
+        with patch("cdash.data.resources.psutil.process_iter", return_value=[mock_proc]):
+            procs = find_claude_processes()
+            assert len(procs) == 0
+
+    def test_handles_empty_cmdline(self):
+        """Handles processes with None cmdline."""
+        mock_proc = MagicMock()
+        mock_proc.info = {"name": "other", "cmdline": None}
+
+        with patch("cdash.data.resources.psutil.process_iter", return_value=[mock_proc]):
+            procs = find_claude_processes()
+            assert len(procs) == 0
+
+
+class TestGetResourceStats:
+    """Tests for get_resource_stats."""
+
+    def test_returns_stats_with_no_processes(self):
+        """Returns zero stats when no Claude processes found."""
+        mock_vm = MagicMock()
+        mock_vm.total = 16 * 1024 * 1024 * 1024  # 16GB
+
+        with (
+            patch("cdash.data.resources.find_claude_processes", return_value=[]),
+            patch("cdash.data.resources.psutil.virtual_memory", return_value=mock_vm),
+        ):
+            stats = get_resource_stats(use_cache=False)
+            assert stats.process_count == 0
+            assert stats.cpu_percent == 0.0
+            assert stats.memory_mb == 0.0
+            assert stats.memory_percent == 0.0
+
+    def test_aggregates_multiple_processes(self):
+        """Aggregates stats across multiple processes."""
+        mock_proc1 = MagicMock()
+        mock_proc1.cpu_percent.return_value = 10.0
+        mock_mem1 = MagicMock()
+        mock_mem1.rss = 100 * 1024 * 1024  # 100MB
+        mock_proc1.memory_info.return_value = mock_mem1
+
+        mock_proc2 = MagicMock()
+        mock_proc2.cpu_percent.return_value = 15.0
+        mock_mem2 = MagicMock()
+        mock_mem2.rss = 200 * 1024 * 1024  # 200MB
+        mock_proc2.memory_info.return_value = mock_mem2
+
+        mock_vm = MagicMock()
+        mock_vm.total = 16 * 1024 * 1024 * 1024  # 16GB
+
+        with (
+            patch(
+                "cdash.data.resources.find_claude_processes", return_value=[mock_proc1, mock_proc2]
+            ),
+            patch("cdash.data.resources.psutil.virtual_memory", return_value=mock_vm),
+        ):
+            stats = get_resource_stats(use_cache=False)
+            assert stats.process_count == 2
+            assert stats.cpu_percent == 25.0
+            assert stats.memory_mb == 300.0
+            # 300MB / 16GB * 100 = 1.831%
+            assert abs(stats.memory_percent - 1.831) < 0.01
+
+
+class TestResourceStatsWidget:
+    """Tests for the ResourceStatsWidget component."""
+
+    @pytest.mark.asyncio
+    async def test_widget_present_in_overview(self):
+        """ResourceStatsWidget is present in Overview tab."""
+        from cdash.app import ClaudeDashApp
+        from cdash.components.resources import ResourceStatsWidget
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            widget = app.query_one(ResourceStatsWidget)
+            assert widget is not None
+
+    @pytest.mark.asyncio
+    async def test_widget_has_stat_blocks(self):
+        """Widget contains CPU, memory, and process count stat blocks."""
+        from cdash.app import ClaudeDashApp
+
+        app = ClaudeDashApp()
+        async with app.run_test() as pilot:
+            cpu_stat = app.query_one("#cpu-stat")
+            mem_stat = app.query_one("#mem-stat")
+            proc_stat = app.query_one("#proc-stat")
+            assert cpu_stat is not None
+            assert mem_stat is not None
+            assert proc_stat is not None


### PR DESCRIPTION
## Summary
- Adds CPU/memory monitoring for Claude processes to Overview tab
- Uses psutil to find and aggregate stats across all Claude processes
- Shows: CPU %, RAM usage, process count
- Refreshes on existing 3s cycle

## Test plan
- [x] `pytest tests/ -v` - 219 tests pass
- [x] Verify widget appears on Overview tab
- [x] Verify stats refresh automatically

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)