### PR TITLE
feat(ui): add loading indicator during startup (#24)

### DIFF
--- a/src/cdash/app.tcss
+++ b/src/cdash/app.tcss
@@ -472,6 +472,42 @@ OverviewTab {
     background: $background;
 }
 
+OverviewContent {
+    height: auto;
+    padding: 0;
+    background: $background;
+}
+
+/* ============================================
+   LOADING SCREEN
+   ============================================ */
+
+LoadingScreen {
+    height: auto;
+    min-height: 10;
+    width: 100%;
+    align: center middle;
+    background: $background;
+}
+
+#loading-content {
+    width: auto;
+    height: auto;
+    padding: 2 4;
+}
+
+#loading-title {
+    text-align: center;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#loading-status {
+    text-align: center;
+    color: $text-muted;
+    margin-top: 1;
+}
+
 /* ============================================
    PLACEHOLDER TAB
    ============================================ */


### PR DESCRIPTION
## Summary
- Add LoadingScreen widget with spinner and status text
- Show loading screen initially, content shown after first data refresh
- 8 new tests for loading indicator behavior

Fixes #24