### PR TITLE
fix(ui): defer initial refresh to show loading screen

### DIFF
--- a/src/cdash/app.py
+++ b/src/cdash/app.py
@@ -146,7 +146,8 @@ class ClaudeDashApp(App):
         self.register_theme(create_claude_theme())
         self.theme = "claude"
 
-        self._refresh_data()
+        # Defer first refresh to allow loading screen to render first
+        self.set_timer(0.1, self._refresh_data)
         self.set_interval(self.REFRESH_INTERVAL, self._refresh_data)
 
     def _refresh_data(self) -> None:

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -183,6 +183,8 @@ class TestTabsRender:
     @pytest.mark.asyncio
     async def test_overview_has_visible_content(self):
         """Overview tab has visible panels."""
+        import asyncio
+
         from textual.widgets import Collapsible
 
         from cdash.components.sessions import ActiveSessionsPanel
@@ -191,6 +193,8 @@ class TestTabsRender:
 
         app = ClaudeDashApp()
         async with app.run_test():
+            # Wait for loading timer to complete
+            await asyncio.sleep(0.15)
             overview = app.query_one(OverviewTab)
             # Sessions panel should be visible
             sessions = overview.query_one(ActiveSessionsPanel)
@@ -263,23 +267,32 @@ class TestLoadingIndicator:
     @pytest.mark.asyncio
     async def test_content_shown_after_refresh(self):
         """Content is shown after refresh_data is called."""
+        import asyncio
+
         app = ClaudeDashApp()
         async with app.run_test():
             overview = app.query_one(OverviewTab)
-            # After app mounts, refresh_data is called which should show content
-            # Since the app auto-refreshes on mount, content should be visible
             content = overview.query_one(OverviewContent)
-            # Content should be displayed after the initial refresh
+            # Initially content is hidden (loading screen visible)
+            assert content.display is False
+            # Wait for the delayed refresh timer (0.1s) plus buffer
+            await asyncio.sleep(0.15)
+            # Content should now be displayed after the initial refresh
             assert content.display is True
 
     @pytest.mark.asyncio
     async def test_loading_hidden_after_refresh(self):
         """Loading screen is hidden after refresh_data is called."""
+        import asyncio
+
         app = ClaudeDashApp()
         async with app.run_test():
             overview = app.query_one(OverviewTab)
-            # After app mounts, refresh_data is called which should hide loading
             loading_screen = overview.query_one(LoadingScreen)
+            # Initially loading screen is visible
+            assert loading_screen.display is True
+            # Wait for the delayed refresh timer (0.1s) plus buffer
+            await asyncio.sleep(0.15)
             # Loading should be hidden after the initial refresh
             assert loading_screen.display is False
 


### PR DESCRIPTION
## Summary
- Loading screen was invisible because `_refresh_data()` was called synchronously in `on_mount()`
- Now uses `set_timer(0.1, ...)` to defer first refresh, allowing loading screen to render
- Updated tests to verify initial loading state visibility

## Root Cause
`on_mount()` → `_refresh_data()` → `show_content()` all happened in the same event loop iteration, before any frame was painted.

## Test plan
- [x] `pytest tests/ -v` passes (213 tests)
- [x] Loading screen visible on startup verified programmatically
- [ ] Manual visual verification

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)