### PR TITLE
feat(plugins): redesign plugins tab with compact table rows

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from cdash.app import ClaudeDashApp
-from cdash.components.plugins import PluginCard, PluginsTab
+from cdash.components.plugins import PluginRow, PluginsTab
 from cdash.data.plugins import Plugin, find_installed_plugins, _is_semver, _parse_semver
 
 
@@ -259,11 +259,11 @@ class TestPluginsTab:
         assert tab is not None
 
 
-class TestPluginCard:
-    """Tests for PluginCard widget."""
+class TestPluginRow:
+    """Tests for PluginRow widget."""
 
-    def test_card_creation(self, tmp_path: Path):
-        """Card can be created from Plugin."""
+    def test_row_creation(self, tmp_path: Path):
+        """Row can be created from Plugin."""
         plugin = Plugin(
             name="test-plugin",
             version="1.0.0",
@@ -275,12 +275,12 @@ class TestPluginCard:
             path=tmp_path,
             enabled=True,
         )
-        card = PluginCard(plugin)
-        assert card.plugin.name == "test-plugin"
-        assert card.enabled is True
+        row = PluginRow(plugin)
+        assert row.plugin.name == "test-plugin"
+        assert row.enabled is True
 
-    def test_card_enabled_state(self, tmp_path: Path):
-        """Card reflects plugin enabled state."""
+    def test_row_enabled_state(self, tmp_path: Path):
+        """Row reflects plugin enabled state."""
         # Enabled plugin
         enabled_plugin = Plugin(
             name="enabled",
@@ -293,8 +293,8 @@ class TestPluginCard:
             path=tmp_path,
             enabled=True,
         )
-        card = PluginCard(enabled_plugin)
-        assert card.enabled is True
+        row = PluginRow(enabled_plugin)
+        assert row.enabled is True
 
         # Disabled plugin
         disabled_plugin = Plugin(
@@ -308,11 +308,11 @@ class TestPluginCard:
             path=tmp_path,
             enabled=False,
         )
-        card = PluginCard(disabled_plugin)
-        assert card.enabled is False
+        row = PluginRow(disabled_plugin)
+        assert row.enabled is False
 
-    def test_card_initial_disabled_state(self, tmp_path: Path):
-        """Card starts with disabled state from plugin."""
+    def test_row_initial_disabled_state(self, tmp_path: Path):
+        """Row starts with disabled state from plugin."""
         plugin = Plugin(
             name="test",
             version="1.0.0",
@@ -324,6 +324,6 @@ class TestPluginCard:
             path=tmp_path,
             enabled=False,
         )
-        card = PluginCard(plugin)
-        assert card.enabled is False
-        assert card.plugin.enabled is False
+        row = PluginRow(plugin)
+        assert row.enabled is False
+        assert row.plugin.enabled is False


### PR DESCRIPTION
## Summary

- Replace 3-column card grid with single-column compact table rows
- Each plugin = 1 line (status, name, version, source, counts)
- Same toggle/persistence behavior preserved

## Before/After

**Before:** 3-col grid, 5+ line cards, wasted vertical space  
**After:** Single-col table, 1 line per plugin, see all at once

## Test plan

- [x] All 205 tests pass
- [ ] Manual: `python -m cdash`, press `3` for Plugins tab
- [ ] Verify j/k navigation, enter/space toggle
- [ ] Verify persistence (quit, relaunch, check state)

Closes #31

---
🤖 Generated with [Claude Code](https://claude.ai/code)