### PR TITLE
docs: sync documentation with post-0.7.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Host resource stats on Overview tab (CPU, memory, disk usage)
+- Liveness indicator dots replacing refresh timestamps
+- Rich session cards with collapsible stats
+- Loading indicator during startup
+- Code change detection with status indicator
+
+### Changed
+
+- CI tab renamed to "GitHub" tab, moved to position 2
+- Plugins tab: compact table rows instead of cards
+- Layout: dashboard-focused redesign
+- Header: k9s-style multi-row with stats and logo
+- Keyboard: header menu for panel switching
+- Header: self-documenting sync indicator
+
+### Removed
+
+- Skills tab
+- Agents tab
+
+### Fixed
+
+- Loading screen visibility on startup
+- Parent project name detection for worktree sessions
+- Hyphenated project names now preserved correctly
+
 ## [0.7.0] - 2026-01-18
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,23 +69,24 @@ After any code change:
 - direnv auto-venv setup
 - Session data loading from ~/.claude/projects/
 - Active session detection (file mtime within 60s)
-- Active sessions panel with project name, prompt preview
+- Active sessions panel with rich collapsible cards
 - Current tool indicator for active sessions
-- Auto-refresh every 10 seconds
+- Auto-refresh every 10 seconds with liveness dots
+- Host resource stats (CPU, memory, disk) on Overview
 - Today's message/tool counts in status bar
 - Weekly trend sparkline
 - Projects ranked by recent activity
 - Tool breakdown with horizontal bar charts
-- Tab navigation with 1-6 keys
-- 6 tabs: Overview, Plugins, MCP Servers, Skills, Agents, CI
-- Plugins tab with installed plugins list
+- Tab navigation with 1-4 keys
+- 4 tabs: Overview, GitHub, MCP Servers, Plugins
+- GitHub tab with Actions monitoring for claude-code-action repos
 - MCP Servers tab with configured servers display
-- Skills tab with skills grouped by plugin
-- Agents tab with user, plugin, and built-in agents
-- CI tab with GitHub Actions monitoring for claude-code-action repos
-- CI activity panel on Overview tab with today's run stats
+- Plugins tab with compact table rows
+- GitHub activity panel on Overview with today's run stats
 - Settings persistence for discovered/hidden repos
 - Session/tool data caching for performance
+- Code change detection with status indicator
+- k9s-style header with stats and logo
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ TUI dashboard for monitoring Claude Code sessions, plugins, and usage.
 
 ## Features
 
-- Real-time session monitoring
+- Real-time session monitoring with collapsible cards
 - Usage trends and statistics
-- Plugin/skill/agent catalog
+- GitHub Actions monitoring (claude-code-action repos)
+- Plugin catalog with compact table rows
 - MCP server status
+- Host resource stats (CPU, memory, disk)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- CHANGELOG: add [Unreleased] section covering 13+ commits since v0.7.0
- CLAUDE.md: update "What's Working" to reflect 4 tabs (removed Skills/Agents)
- README: update features list to match current state

## Changes Since v0.7.0
**Added:** host stats, liveness dots, collapsible session cards, loading indicator, code change detection
**Changed:** CI→GitHub tab, compact plugin rows, k9s-style header
**Removed:** Skills tab, Agents tab
**Fixed:** loading screen, worktree project names, hyphenated names

🤖 Generated with [Claude Code](https://claude.com/claude-code)