### PR TITLE
feat(plugins): add column headers to table

### DIFF
--- a/src/cdash/components/plugins.py
+++ b/src/cdash/components/plugins.py
@@ -142,6 +142,56 @@ class PluginRow(Widget, can_focus=True):
         self.post_message(self.Toggled(self, self.enabled))
 
 
+class PluginHeader(Widget):
+    """Header row for the plugins table."""
+
+    DEFAULT_CSS = """
+    PluginHeader {
+        width: 100%;
+        height: 1;
+        padding: 0 1;
+    }
+
+    PluginHeader > Horizontal {
+        width: 100%;
+        height: 1;
+    }
+
+    PluginHeader .row-status {
+        width: 3;
+        color: $text-muted;
+    }
+
+    PluginHeader .row-name {
+        width: 22;
+        color: $text-muted;
+    }
+
+    PluginHeader .row-version {
+        width: 12;
+        color: $text-muted;
+    }
+
+    PluginHeader .row-source {
+        width: 20;
+        color: $text-muted;
+    }
+
+    PluginHeader .row-counts {
+        width: 1fr;
+        color: $text-muted;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            yield Static("", classes="row-status")
+            yield Static("NAME", classes="row-name")
+            yield Static("VERSION", classes="row-version")
+            yield Static("SOURCE", classes="row-source")
+            yield Static("COUNTS", classes="row-counts")
+
+
 class PluginsTab(VerticalScroll):
     """Plugins tab showing installed plugins as compact table rows."""
 
@@ -183,6 +233,7 @@ class PluginsTab(VerticalScroll):
         yield Static(
             "[space/enter] toggle  [arrows] navigate  [r] refresh", id="plugins-hint"
         )
+        yield PluginHeader()
 
     def on_mount(self) -> None:
         """Load plugins when mounted."""
@@ -251,7 +302,9 @@ def _format_counts(skills: int, agents: int) -> str:
     """Format skill/agent counts for display."""
     parts = []
     if skills > 0:
-        parts.append(f"{skills}s")
+        label = "skill" if skills == 1 else "skills"
+        parts.append(f"{skills} {label}")
     if agents > 0:
-        parts.append(f"{agents}a")
+        label = "agent" if agents == 1 else "agents"
+        parts.append(f"{agents} {label}")
     return ", ".join(parts) if parts else ""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from cdash.app import ClaudeDashApp
-from cdash.components.plugins import PluginRow, PluginsTab
+from cdash.components.plugins import PluginHeader, PluginRow, PluginsTab, _format_counts
 from cdash.data.plugins import Plugin, find_installed_plugins, _is_semver, _parse_semver
 
 
@@ -327,3 +327,43 @@ class TestPluginRow:
         row = PluginRow(plugin)
         assert row.enabled is False
         assert row.plugin.enabled is False
+
+
+class TestPluginHeader:
+    """Tests for PluginHeader widget."""
+
+    def test_header_can_be_created(self):
+        """PluginHeader widget can be instantiated."""
+        header = PluginHeader()
+        assert header is not None
+
+
+class TestFormatCounts:
+    """Tests for count formatting."""
+
+    def test_format_counts_empty(self):
+        """No skills/agents returns empty string."""
+        assert _format_counts(0, 0) == ""
+
+    def test_format_counts_skills_only_singular(self):
+        """Single skill uses singular form."""
+        assert _format_counts(1, 0) == "1 skill"
+
+    def test_format_counts_skills_only_plural(self):
+        """Multiple skills use plural form."""
+        assert _format_counts(2, 0) == "2 skills"
+        assert _format_counts(10, 0) == "10 skills"
+
+    def test_format_counts_agents_only_singular(self):
+        """Single agent uses singular form."""
+        assert _format_counts(0, 1) == "1 agent"
+
+    def test_format_counts_agents_only_plural(self):
+        """Multiple agents use plural form."""
+        assert _format_counts(0, 3) == "3 agents"
+
+    def test_format_counts_both(self):
+        """Both skills and agents are formatted together."""
+        assert _format_counts(1, 1) == "1 skill, 1 agent"
+        assert _format_counts(2, 3) == "2 skills, 3 agents"
+        assert _format_counts(5, 1) == "5 skills, 1 agent"


### PR DESCRIPTION
## Summary
- Add PluginHeader widget with NAME/VERSION/SOURCE/COUNTS labels
- Update count format from "2s" to "2 skills" for better readability
- Headers align with existing column widths via CSS classes

## Test plan
- [x] All 212 tests pass
- [x] PluginHeader widget instantiates correctly
- [x] Count formatting handles singular/plural forms

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)