### PR TITLE
fix(ui): replace misleading context progress bar with file size indicator

### DIFF
--- a/src/cdash/components/sessions.py
+++ b/src/cdash/components/sessions.py
@@ -8,7 +8,13 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from cdash.components.indicators import RefreshIndicator
-from cdash.data.sessions import Session, format_duration, format_relative_time, load_all_sessions
+from cdash.data.sessions import (
+    Session,
+    format_duration,
+    format_file_size,
+    format_relative_time,
+    load_all_sessions,
+)
 from cdash.theme import AMBER, CORAL, GREEN, RED, TEXT_MUTED
 
 
@@ -174,12 +180,12 @@ class SessionCardFrame(Vertical):
         title = s.github_repo or format_project_display(s.project_name)
         lines.append(f"{status} [bold]{title}[/]  {badge}")
 
-        # Line 2: branch + duration + context bar
+        # Line 2: branch + duration + file size
         branch = s.git_branch[:40] if s.git_branch else ""
         dur = format_duration(s.started_at)
         duration = f"{dur}" if dur else ""
-        context_bar = self._render_context_bar(s.context_percentage)
-        lines.append(f"  [{TEXT_MUTED}]{branch}[/]  {duration}  {context_bar}")
+        file_size = format_file_size(s.context_chars)
+        lines.append(f"  [{TEXT_MUTED}]{branch}[/]  {duration}  💾 {file_size}")
 
         # Line 3: prompt preview
         if s.full_prompt:
@@ -334,12 +340,12 @@ class SessionCard(Static):
         title = s.github_repo or format_project_display(s.project_name)
         lines.append(f"{status} [bold]{title}[/]  {badge}")
 
-        # Line 2: branch + duration + context bar
+        # Line 2: branch + duration + file size
         branch = s.git_branch[:40] if s.git_branch else ""
         dur = format_duration(s.started_at)
         duration = f"{dur}" if dur else ""
-        context_bar = self._render_context_bar(s.context_percentage)
-        lines.append(f"  [{TEXT_MUTED}]{branch}[/]  {duration}  {context_bar}")
+        file_size = format_file_size(s.context_chars)
+        lines.append(f"  [{TEXT_MUTED}]{branch}[/]  {duration}  💾 {file_size}")
 
         # Line 3: prompt preview
         if s.full_prompt:

--- a/src/cdash/data/sessions.py
+++ b/src/cdash/data/sessions.py
@@ -97,6 +97,25 @@ def format_relative_time(timestamp: float) -> str:
     return f"{age_mins // 60}h"
 
 
+def format_file_size(size_bytes: int) -> str:
+    """Format file size as human-readable string.
+
+    Args:
+        size_bytes: Size in bytes
+
+    Returns:
+        Human-readable size string (e.g., "64KB", "1.2MB")
+    """
+    if size_bytes < 1024:
+        return f"{size_bytes}B"
+    elif size_bytes < 1024 * 1024:
+        kb = size_bytes / 1024
+        return f"{kb:.0f}KB" if kb >= 10 else f"{kb:.1f}KB"
+    else:
+        mb = size_bytes / (1024 * 1024)
+        return f"{mb:.1f}MB"
+
+
 # Cache for GitHub repo lookups
 _github_repo_cache: dict[str, str | None] = {}
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -9,6 +9,7 @@ from cdash.data.sessions import (
     _decode_project_path,
     find_session_files,
     format_duration,
+    format_file_size,
     list_projects,
     parse_session_file,
 )
@@ -323,6 +324,34 @@ class TestFormatDuration:
         started = time.time() - 24 * 60 * 60
         result = format_duration(started)
         assert result == "1d"
+
+
+class TestFormatFileSize:
+    """Tests for format_file_size helper."""
+
+    def test_bytes(self):
+        """Small values show as bytes."""
+        assert format_file_size(0) == "0B"
+        assert format_file_size(512) == "512B"
+        assert format_file_size(1023) == "1023B"
+
+    def test_kilobytes_small(self):
+        """Values under 10KB show one decimal."""
+        assert format_file_size(1024) == "1.0KB"
+        assert format_file_size(5 * 1024) == "5.0KB"
+        assert format_file_size(9 * 1024 + 512) == "9.5KB"
+
+    def test_kilobytes_large(self):
+        """Values 10KB+ show no decimals."""
+        assert format_file_size(10 * 1024) == "10KB"
+        assert format_file_size(64 * 1024) == "64KB"
+        assert format_file_size(999 * 1024) == "999KB"
+
+    def test_megabytes(self):
+        """MB values show one decimal."""
+        assert format_file_size(1024 * 1024) == "1.0MB"
+        assert format_file_size(int(1.5 * 1024 * 1024)) == "1.5MB"
+        assert format_file_size(10 * 1024 * 1024) == "10.0MB"
 
 
 class TestNewSessionFields:


### PR DESCRIPTION
## Summary
- Add `format_file_size()` helper to display human-readable sizes (B, KB, MB)
- Replace misleading progress bar with disk icon + file size display
- Add 4 unit tests for the new helper

## Problem
Session cards showed a progress bar with percentage that appeared to represent context window usage, but was actually `file_size / 4` (rough token estimate).

Users saw 100% and thought their context was full when it was just a large transcript file.

## Before
```
4m ████░░░░ 1%
```

## After
```
4m 💾 64KB
```

## Test plan
- [x] All 223 tests pass (4 new)
- [x] Visual inspection of file size display

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)